### PR TITLE
[Fix] 차트 거래내역, 오더북 렌더링 문제 해결

### DIFF
--- a/components/trade/chart/orderbook/Orderbook.jsx
+++ b/components/trade/chart/orderbook/Orderbook.jsx
@@ -1,8 +1,8 @@
 import { useState, useCallback, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { globalColors } from '@/globalColors';
-import { LinearProgress } from '@mui/material';
 import { PriceTypo, HeadTypo } from '@/defaultTheme';
+import { CircularProgress } from '@mui/material';
 
 export default function Orderbook({ orderbookData }) {
   const rate = useSelector(state => state.chart.rate);
@@ -42,124 +42,126 @@ export default function Orderbook({ orderbookData }) {
     setBidMaxSize(maxBidSize);
   }, [getMaxSize, orderbookData]);
 
-  if (!orderbookData) {
-    return <LinearProgress color="primary" />;
-  }
-
   return (
-    <>
-      {orderbookData?.orderbook_units && (
-        <div className="w-full h-[28.1rem] bg-white overflow-y-auto">
-          <table className="w-full border-collapse">
-            <thead className="sticky top-0 z-10 bg-main">
-              <tr>
-                <th className="py-[0.25rem] w-1/3 text-center">
-                  <HeadTypo>매도 물량</HeadTypo>
-                </th>
-                <th className="py-[0.25rem] w-1/3 text-center">
-                  <HeadTypo>가격</HeadTypo>
-                </th>
-                <th className="py-[0.25rem] w-1/3 text-center">
-                  <HeadTypo>매수 물량</HeadTypo>
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {/* 매도 물량 */}
-              {[...orderbookData.orderbook_units]
-                .reverse()
-                .map((element, index) => (
-                  <tr key={`${element.ask_price}${index}`}>
-                    <td className="py-1 bg-[#b6f5fa] h-[1rem] border-b-[0.063rem] border-color:rgba(224, 224, 224, 1)] border-solid">
-                      <div className="relative">
-                        <PriceTypo
-                          fontSize={10}
-                          sx={{
-                            position: 'absolute',
-                            right: 0,
-                          }}
-                        >
-                          {Number(element.ask_size).toFixed(4)}
-                        </PriceTypo>
-                        <div
-                          className={`absolute opacity-50 max-w-[100%] right-0 -top-[0.4rem] h-[0.6rem] bg-[#42b3e3]`}
-                          style={{
-                            width: `${(element.ask_size / askMaxSize) * 100}%`,
-                          }}
-                        />
-                      </div>
-                    </td>
-                    <td className="p-1 border-b-[0.063rem] border-color:rgba(224, 224, 224, 1)] border-solid">
-                      <div className="flex justify-between">
-                        <PriceTypo
-                          color={numColor}
-                          fontSize={12}
-                          fontWeight={'bold'}
-                        >
-                          {Number(element.ask_price).toLocaleString()}
-                        </PriceTypo>
-                        <PriceTypo fontSize={12} color={numColor}>
-                          {Number(rate) > 0 ? '+' : ''}
-                          {prevPrice &&
-                            Number(
-                              ((element.ask_price - prevPrice) / prevPrice) *
-                                100,
-                            ).toFixed(2)}
-                          {prevPrice && '%'}
-                        </PriceTypo>
-                      </div>
-                    </td>
-                    <td className="p-1 border-b-[0.063rem] border-color:rgba(224, 224, 224, 1)] border-solid" />
-                  </tr>
-                ))}
-              {/* 매수 물량 */}
-              {[...orderbookData.orderbook_units].map((element, index) => (
-                <tr key={`bid_${index}`}>
-                  <td className="p-1 border-b-[0.063rem] border-color:rgba(224, 224, 224, 1)] border-solid" />
-                  <td className="p-1 border-b-[0.063rem] border-color:rgba(224, 224, 224, 1)] border-solid">
+    <div className="w-full h-[28.1rem] overflow-y-scroll bg-white">
+      <table className="w-full border-collapse">
+        <thead className="h-[2.5rem] sticky top-0 z-10 bg-main">
+          <tr>
+            <th className="py-[0.25rem] w-1/3">
+              <HeadTypo>매도 물량</HeadTypo>
+            </th>
+            <th className="py-[0.25rem] w-1/3">
+              <HeadTypo>가격</HeadTypo>
+            </th>
+            <th className="py-[0.25rem] w-1/3">
+              <HeadTypo>매수 물량</HeadTypo>
+            </th>
+          </tr>
+        </thead>
+        {orderbookData?.orderbook_units && orderbookData[0] !== 0 ? (
+          <tbody>
+            {/* 매도 */}
+            {[...orderbookData.orderbook_units]
+              .reverse()
+              .map((element, index) => (
+                <tr key={`${element.ask_price}${index}`}>
+                  <td className="table-cell w-1/3 py-1 bg-[#b6f5fa] h-[1rem] border-b-[0.063rem] border-color:rgba(224, 224, 224, 1)] border-solid">
+                    <div className="relative">
+                      <PriceTypo
+                        fontSize={10}
+                        sx={{
+                          position: 'absolute',
+                          right: 0,
+                        }}
+                      >
+                        {Number(element.ask_size).toFixed(4)}
+                      </PriceTypo>
+                      <div
+                        className={`absolute opacity-50 max-w-[100%] right-0 -top-[0.4rem] h-[0.6rem] bg-[#42b3e3]`}
+                        style={{
+                          width: `${(element.ask_size / askMaxSize) * 100}%`,
+                        }}
+                      />
+                    </div>
+                  </td>
+                  <td className="table-cell w-1/3 p-1 border-b-[0.063rem] border-color:rgba(224, 224, 224, 1)] border-solid">
                     <div className="flex justify-between">
                       <PriceTypo
                         color={numColor}
                         fontSize={12}
                         fontWeight={'bold'}
                       >
-                        {Number(element.bid_price).toLocaleString()}
+                        {Number(element.ask_price).toLocaleString()}
                       </PriceTypo>
                       <PriceTypo fontSize={12} color={numColor}>
                         {Number(rate) > 0 ? '+' : ''}
                         {prevPrice &&
                           Number(
-                            ((element.bid_price - prevPrice) / prevPrice) * 100,
+                            ((element.ask_price - prevPrice) / prevPrice) * 100,
                           ).toFixed(2)}
                         {prevPrice && '%'}
                       </PriceTypo>
                     </div>
                   </td>
-                  <td className="py-1 bg-[#f5bfd0] h-[1rem] border-b-[0.063rem] border-color:rgba(224, 224, 224, 1)] border-solid">
-                    <div className="relative">
-                      <PriceTypo
-                        fontSize={10}
-                        sx={{
-                          position: 'absolute',
-                          left: 0,
-                        }}
-                      >
-                        {Number(element.bid_size).toFixed(4)}
-                      </PriceTypo>
-                      <div
-                        className={`absolute opacity-50 max-w-[100%] left-0 -top-[0.5rem] h-[0.6rem] bg-[#b567b0]`}
-                        style={{
-                          width: `${(element.bid_size / bidMaxSize) * 100}%`,
-                        }}
-                      />
-                    </div>
-                  </td>
+                  <td className="table-cell w-1/3 p-1 border-b-[0.063rem] border-color:rgba(224, 224, 224, 1)] border-solid" />
                 </tr>
               ))}
-            </tbody>
-          </table>
-        </div>
-      )}
-    </>
+
+            {/* 매수 */}
+            {[...orderbookData.orderbook_units].map((element, index) => (
+              <tr key={`bid_${index}`}>
+                <td className="table-cell w-1/3 p-1 border-b-[0.063rem] border-color:rgba(224, 224, 224, 1)] border-solid" />
+                <td className="table-cell w-1/3 p-1 border-b-[0.063rem] border-color:rgba(224, 224, 224, 1)] border-solid">
+                  <div className="flex justify-between">
+                    <PriceTypo
+                      color={numColor}
+                      fontSize={12}
+                      fontWeight={'bold'}
+                    >
+                      {Number(element.bid_price).toLocaleString()}
+                    </PriceTypo>
+                    <PriceTypo fontSize={12} color={numColor}>
+                      {Number(rate) > 0 ? '+' : ''}
+                      {prevPrice &&
+                        Number(
+                          ((element.bid_price - prevPrice) / prevPrice) * 100,
+                        ).toFixed(2)}
+                      {prevPrice && '%'}
+                    </PriceTypo>
+                  </div>
+                </td>
+                <td className="table-cell w-1/3 py-1 bg-[#f5bfd0] h-[1rem] border-b-[0.063rem] border-color:rgba(224, 224, 224, 1)] border-solid">
+                  <div className="relative">
+                    <PriceTypo
+                      fontSize={10}
+                      sx={{
+                        position: 'absolute',
+                        left: 0,
+                      }}
+                    >
+                      {Number(element.bid_size).toFixed(4)}
+                    </PriceTypo>
+                    <div
+                      className={`absolute opacity-50 max-w-[100%] left-0 -top-[0.5rem] h-[0.6rem] bg-[#b567b0]`}
+                      style={{
+                        width: `${(element.bid_size / bidMaxSize) * 100}%`,
+                      }}
+                    />
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        ) : (
+          <tbody>
+            <tr>
+              <td>
+                <CircularProgress color="primary" />
+              </td>
+            </tr>
+          </tbody>
+        )}
+      </table>
+    </div>
   );
 }

--- a/components/trade/chart/orderbook/OrderbookContainer.jsx
+++ b/components/trade/chart/orderbook/OrderbookContainer.jsx
@@ -1,42 +1,35 @@
-import { memo, useEffect, useState } from 'react';
+import { useEffect, useState, memo } from 'react';
 import { useSelector } from 'react-redux';
-import { LinearProgress } from '@mui/material';
 import axios from 'axios';
 import Orderbook from '@/components/trade/chart/orderbook/Orderbook';
 
 function OrderbookContainer() {
-  const [isLoading, setIsLoading] = useState(false);
   const [orderbookData, setOrderbookData] = useState([]);
+  const [currentCode, setCurrentCode] = useState(null);
+
   const code = useSelector(state => state.chart.code);
   const intervalTime = useSelector(state => state.chart.intervalTime);
 
   useEffect(() => {
     if (code) {
-      let firstLoad = true;
+      if (code !== currentCode) setCurrentCode(code);
       const fetchOrderbookData = async () => {
-        if (firstLoad) setIsLoading(true);
         try {
           const response = await axios.get(`/api/orderbook/${code}`);
           const data = response.data;
           setOrderbookData(...data);
         } catch (error) {
           console.error('실시간 오더북 데이터 다운로드 에러: ', error);
-        } finally {
-          if (firstLoad) {
-            setIsLoading(false);
-            firstLoad = false;
-          }
         }
       };
-
+      setOrderbookData([0]);
       fetchOrderbookData();
       const interval = setInterval(fetchOrderbookData, intervalTime);
       return () => clearInterval(interval);
     }
-  }, [code, intervalTime]);
-
-  if (isLoading) return <LinearProgress color="primary" />;
+  }, [code, currentCode, intervalTime]);
 
   return <Orderbook orderbookData={orderbookData} />;
 }
+
 export default memo(OrderbookContainer);

--- a/components/trade/chart/tradeHistory/TradeHistory.jsx
+++ b/components/trade/chart/tradeHistory/TradeHistory.jsx
@@ -1,5 +1,6 @@
 import { HeadTypo, NGTypo, PriceTypo } from '@/defaultTheme';
 import { globalColors } from '@/globalColors';
+import { CircularProgress } from '@mui/material';
 
 export default function TradeHistory({ tradeData }) {
   const timestampToTime = timestamp => {
@@ -9,41 +10,41 @@ export default function TradeHistory({ tradeData }) {
   };
 
   return (
-    <div className="max-w-[62.5rem] h-[28.1rem] overflow-auto bg-white">
-      {tradeData?.length && (
-        <table className="w-full">
-          <thead className="sticky top-0 z-10 bg-main">
-            <tr>
-              <th className="py-[0.25rem] bg-main">
-                <HeadTypo>체결 시간</HeadTypo>
-              </th>
-              <th className="py-[0.25rem] bg-main">
-                <HeadTypo>체결 가격</HeadTypo>
-              </th>
-              <th className="py-[0.25rem] bg-main">
-                <HeadTypo>체결량</HeadTypo>
-              </th>
-              <th className="py-[0.25rem] bg-main">
-                <HeadTypo>체결금액</HeadTypo>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
+    <div className="max-w-[62.5rem] h-[28.1rem] overflow-y-scroll bg-white">
+      <table className="w-full">
+        <thead className="h-[2.5rem] sticky top-0 z-10 bg-main">
+          <tr>
+            <th className="py-[0.25rem] w-1/4">
+              <HeadTypo>체결 시간</HeadTypo>
+            </th>
+            <th className="py-[0.25rem] w-1/4">
+              <HeadTypo>체결 가격</HeadTypo>
+            </th>
+            <th className="py-[0.25rem] w-1/4">
+              <HeadTypo>체결량</HeadTypo>
+            </th>
+            <th className="py-[0.25rem] w-1/4">
+              <HeadTypo>체결금액</HeadTypo>
+            </th>
+          </tr>
+        </thead>
+        {tradeData?.length && tradeData[0] !== 0 ? (
+          <tbody className="min-h-[25.6rem]">
             {tradeData.slice().map(data => (
               <tr
                 key={`${data.sequential_id}-${data.timestamp}-${Math.random()}`}
               >
-                <td className="table-cell border-b-[0.063rem] border-color:rgba(224, 224, 224, 1)] border-solid text-center">
+                <td className="table-cell w-1/4 border-b-[0.063rem] border-color:rgba(224, 224, 224, 1)] border-solid text-center">
                   <NGTypo fontSize={12}>
                     {timestampToTime(data.timestamp)}
                   </NGTypo>
                 </td>
-                <td className="table-cell border-b-[0.063rem] border-color:rgba(224, 224, 224, 1)] border-solid text-center">
+                <td className="table-cell w-1/4 border-b-[0.063rem] border-color:rgba(224, 224, 224, 1)] border-solid text-center">
                   <NGTypo fontSize={12}>
                     {Number(data.trade_price).toLocaleString()}원
                   </NGTypo>
                 </td>
-                <td className="table-cell border-b-[0.063rem] border-color:rgba(224, 224, 224, 1)] border-solid text-center">
+                <td className="table-cell w-1/4 border-b-[0.063rem] border-color:rgba(224, 224, 224, 1)] border-solid text-center">
                   <PriceTypo
                     fontSize={12}
                     color={
@@ -55,7 +56,7 @@ export default function TradeHistory({ tradeData }) {
                     {data.trade_volume}
                   </PriceTypo>
                 </td>
-                <td className="table-cell border-b-[0.063rem] border-color:rgba(224, 224, 224, 1)] border-solid text-center">
+                <td className="table-cell w-1/4 border-b-[0.063rem] border-color:rgba(224, 224, 224, 1)] border-solid text-center">
                   <PriceTypo
                     fontSize={12}
                     color={
@@ -73,8 +74,16 @@ export default function TradeHistory({ tradeData }) {
               </tr>
             ))}
           </tbody>
-        </table>
-      )}
+        ) : (
+          <tbody>
+            <tr>
+              <td>
+                <CircularProgress color="primary" />
+              </td>
+            </tr>
+          </tbody>
+        )}
+      </table>
     </div>
   );
 }

--- a/components/trade/chart/tradeHistory/TradeHistoryContainer.jsx
+++ b/components/trade/chart/tradeHistory/TradeHistoryContainer.jsx
@@ -1,11 +1,9 @@
-import { memo, useEffect, useState } from 'react';
+import { useEffect, useState, memo } from 'react';
 import { useSelector } from 'react-redux';
-import { LinearProgress } from '@mui/material';
 import axios from 'axios';
 import TradeHistory from '@/components/trade/chart/tradeHistory/TradeHistory';
 
 function TradeHistoryContainer() {
-  const [isLoading, setIsLoading] = useState(false);
   const [tradeData, setTradeData] = useState([]);
   const [currentCode, setCurrentCode] = useState(null);
 
@@ -15,32 +13,25 @@ function TradeHistoryContainer() {
   useEffect(() => {
     if (code) {
       if (code !== currentCode) setCurrentCode(code);
-      let firstLoad = true;
       const fetchTradeData = async () => {
-        if (firstLoad)
-          try {
-            const response = await axios.get(`/api/trade/${code}`);
-            const data = response.data;
-            setTradeData(prevTradeData => {
-              const newData = data.filter(
-                item =>
-                  !prevTradeData.some(
-                    prevItem => prevItem.sequential_id === item.sequential_id,
-                  ),
-              );
-              const combinedData = [...newData, ...prevTradeData]
-                .sort((a, b) => b.sequential_id - a.sequential_id) // 최신순 정렬
-                .slice(0, 30);
-              return combinedData;
-            });
-          } catch (error) {
-            console.error('실시간 거래 내역 데이터 다운로드 에러: ', error);
-          } finally {
-            if (firstLoad) {
-              setIsLoading(false);
-              firstLoad = false;
-            }
-          }
+        try {
+          const response = await axios.get(`/api/trade/${code}`);
+          const data = response.data;
+          setTradeData(prevTradeData => {
+            const newData = data.filter(
+              item =>
+                !prevTradeData.some(
+                  prevItem => prevItem.sequential_id === item.sequential_id,
+                ),
+            );
+            const combinedData = [...newData, ...prevTradeData]
+              .sort((a, b) => b.sequential_id - a.sequential_id)
+              .slice(0, 30);
+            return combinedData;
+          });
+        } catch (error) {
+          console.error('실시간 거래 내역 데이터 다운로드 에러: ', error);
+        }
       };
       setTradeData([0]);
       fetchTradeData();
@@ -48,8 +39,6 @@ function TradeHistoryContainer() {
       return () => clearInterval(interval);
     }
   }, [code, currentCode, intervalTime]);
-
-  if (isLoading) <LinearProgress color="primary" />;
 
   return <TradeHistory tradeData={tradeData} />;
 }

--- a/defaultTheme.js
+++ b/defaultTheme.js
@@ -111,7 +111,7 @@ export const SubTitle = styled(Typography)(() => ({
 export const DescriptionTypo = styled(Typography)(() => ({
   fontFamily: 'NEXON Lv1 Gothic OTF',
   color: globalColors.black,
-  textShadow: globalColors.shadow_text,
+  // textShadow: globalColors.shadow_text,
   fontWeight: 'bold',
   '@media (max-width:900px)': {
     fontSize: '0.5rem',

--- a/pages/trade/tradeHistory.jsx
+++ b/pages/trade/tradeHistory.jsx
@@ -22,7 +22,7 @@ export async function getStaticProps() {
 }
 
 function TradeHistory({ marketCodes }) {
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(false);
   const [isConnected, setIsConnected] = useState(false);
   const [tradeData, setTradeData] = useState([]);
   const [currentCode, setCurrentCode] = useState(
@@ -31,8 +31,7 @@ function TradeHistory({ marketCodes }) {
 
   useEffect(() => {
     if (currentCode) {
-      setTradeData([]);
-
+      setIsLoading(true);
       const fetchTradeData = async () => {
         try {
           const response = await axios.get(`/api/trade/${currentCode}`);
@@ -47,9 +46,8 @@ function TradeHistory({ marketCodes }) {
             );
 
             const updatedTradeData = [...newData.reverse(), ...prevTradeData]
-              .slice(0, 20)
-              .reverse();
-
+              .sort((a, b) => b.sequential_id - a.sequential_id)
+              .slice(0, 20);
             return updatedTradeData;
           });
         } catch (error) {
@@ -59,7 +57,7 @@ function TradeHistory({ marketCodes }) {
           setIsConnected(true);
         }
       };
-
+      setTradeData([0]);
       fetchTradeData();
       const interval = setInterval(fetchTradeData, 3000);
       return () => clearInterval(interval);


### PR DESCRIPTION
tradeData?.length && tradeData[0] !== 0 ? 일 때 렌더링 tbody만 리렌더링 시키고
fallback UI를 CircularProgress로 설정함. 상태로 관리하던 isLoading을 fallback UI로 대체한 셈.
그리고 데이터가 바뀔 때마다 레이아웃이 들썩거리는건 스크롤바가 없어졌다가 다시 나타나면서 문제가 발생하던 것.
그래서 overflow-y-auto를 overflow-y-scroll로 변경해 줌